### PR TITLE
Better version check for Rsubread

### DIFF
--- a/runfeatureCountFUN.R
+++ b/runfeatureCountFUN.R
@@ -9,7 +9,7 @@ checkRsubreadVersion<- function(){
       print("I did not find Rsubread so I am installing it...")
       BiocInstaller::biocLite("Rsubread",dependencies = TRUE, ask = FALSE)
     }else{
-      if(all(as.numeric_version(installed.packages()[grep("Rsubread",installed.packages()),"Version"])<'1.26.1')){
+      if(all(as.numeric_version(packageVersion("Rsubread"))<'1.26.1')){
           print("I need newer Rsubread so I am updating it...")
           BiocInstaller::biocUpdatePackages("Rsubread", ask=FALSE)
        }


### PR DESCRIPTION
Current Rsubread version control leads to the following error in R 3.5.2:

```
Error in installed.packages()[grep("Rsubread", installed.packages()),  :
  subscript out of bounds
Calls: checkRsubreadVersion -> as.numeric_version -> is.numeric_version
Execution halted
```

Here `grep("Rsubread", installed.packages())` returns `c(123,1451)` and installed.packages()[c(123,1451)] leads to subscript out of bounds.