### PR TITLE
Fix symlinks

### DIFF
--- a/zUMIs-master.sh
+++ b/zUMIs-master.sh
@@ -173,7 +173,7 @@ then
   echo "Filtering..."
 
   f=`cut -d' ' -f1 <(echo $fqfiles)` # the first fastq file to determine gzip status
-  fullsize=`stat --printf="%s" $f`
+  fullsize=`stat -L --printf="%s" $f`
 
   tmpMerge=$outdir/zUMIs_output/.tmpMerge/
 


### PR DESCRIPTION
Fixes #140 
The -L option follows symlinks and thus allows to determine the file size correctly.