### PR TITLE
Fix negative length vectors are not allowed

### DIFF
--- a/UMIstuffFUN.R
+++ b/UMIstuffFUN.R
@@ -246,11 +246,11 @@ ham_helper_fun <- function(x, molecule_mapping = FALSE){
   #join bc-wise total counts
   rcl<-reads[ftype %in% ft][bccount ,nomatch=0][  n>=nmin ] #
   if(nrow(rcl)>0)  {
-    return( rcl[ rcl[ ,exn:=.N,by=RG
-                      ][         , targetN:=exn  # use binomial to break down to exon sampling
-                                 ][ n> nmax, targetN:=rbinom(1,nmax,mean(exn)/mean(n) ), by=RG
-                                    ][targetN>exn, targetN:=exn][is.na(targetN),targetN :=0
-                                                                 ][ ,sample(.I , median(na.omit(targetN))),by = RG]$V1 ])
+    return( rcl[ unlist(rcl[ ,exn:=.N,by=RG
+                           ][         , targetN:=exn  # use binomial to break down to exon sampling
+                                      ][ n> nmax, targetN:=rbinom(1,nmax,mean(exn)/mean(n) ), by=RG
+                                      ][targetN>exn, targetN:=exn][is.na(targetN),targetN :=0
+                                                                 ][ ,list(list(sample(.I , targetN))),by = RG]$V1) ])
   }else{ return(NULL) }
 }
 


### PR DESCRIPTION
Aggregate indices as list inside data.table and extract them as vector using unlist().
This fixes #94. This happens when the data.table contains too many elements and somehow internally exceeds the 32 bit integer limits. By grouping the indices per RG as list we avoid the data.table growing too much.

Since the targetN is already set to 0 if it is NA in the operation before, I removed the na.omit. Also since the targetN is the same for every RG (due to rbinom(1,nmax,mean(exn)/mean(n) returning a single number) I removed the median computation.