### PR TITLE
Speed up when the dataset can be in a single chunk

### DIFF
--- a/UMIstuffFUN.R
+++ b/UMIstuffFUN.R
@@ -19,6 +19,7 @@ splitRG<-function(bccount,mem){
   cs=0
   chunkID=1
   bccount[,chunkID:=0]
+  if(sum(bccount$n) > maxR) {
   for(i in 1:nc){
     cs=cs+bccount[i]$n
     if(bccount[i]$n>maxR){
@@ -33,6 +34,7 @@ splitRG<-function(bccount,mem){
     }
     bccount[i][,"chunkID"]=chunkID
   }
+    }
   return(bccount)
 }
 

--- a/UMIstuffFUN.R
+++ b/UMIstuffFUN.R
@@ -18,7 +18,7 @@ splitRG<-function(bccount,mem){
   nc<-nrow(bccount)
   cs=0
   chunkID=1
-  bccount[,chunkID:=0]
+  bccount[,chunkID:=1]
   if(sum(bccount$n) > maxR) {
   for(i in 1:nc){
     cs=cs+bccount[i]$n


### PR DESCRIPTION
First, thanks for a very nice pipeline. 

The FOR loop assigning cell barcodes to chunks in the UMIstuffFUN.R can be very slow when there is a large amount of barcodes and it is not needed when there is only a single chunk anyway. To avoid running this loop unnecessarily I have changed the default chunk index to 1 to avoid later problems and inserted an IF statement to only run the loop if the total number of reads is larger than maxR.

Best,
Jesper