### PR TITLE
Config file check for reads per cell

### DIFF
--- a/checkRequirements.R
+++ b/checkRequirements.R
@@ -1,12 +1,14 @@
 #!/usr/bin/env Rscript
 
 ## hard-coded list of required packages
+## [found by looking for require, library and "::" in R code]
 neededPackages <-
     c("AnnotationDbi", "cowplot", "data.table", "dplyr", "extraDistr",
       "foreach", "GenomicAlignments", "GenomicFeatures",
-      "GenomicRanges", "ggplot2", "inflection", "Matrix", "mclust",
+      "GenomicRanges", "ggplot2", "ggrastr", "inflection", "Matrix", "mclust",
       "methods", "parallel", "plyranges", "Rsamtools", "Rsubread",
-      "shiny", "shinyBS", "yaml");
+      "shiny", "shinyBS", "shinythemes", "stringdist", "stringr", "table",
+      "tibble", "unixtools", "yaml");
 
 cat("Checking R packages... ");
 

--- a/checkRequirements.R
+++ b/checkRequirements.R
@@ -37,5 +37,3 @@ if(length(neededPackages) > 0){
 } else {
     cat("Great, all required R packages have been installed!\n");
 }
-
-quit(status=1, save="no");

--- a/checkRequirements.R
+++ b/checkRequirements.R
@@ -7,8 +7,8 @@ neededPackages <-
       "foreach", "GenomicAlignments", "GenomicFeatures",
       "GenomicRanges", "ggplot2", "ggrastr", "inflection", "Matrix", "mclust",
       "methods", "parallel", "plyranges", "Rsamtools", "Rsubread",
-      "shiny", "shinyBS", "shinythemes", "stringdist", "stringr", "table",
-      "tibble", "unixtools", "yaml");
+      "shiny", "shinyBS", "shinythemes", "stringdist", "stringr",
+      "tibble", "yaml");
 
 cat("Checking R packages... ");
 

--- a/checkRequirements.R
+++ b/checkRequirements.R
@@ -1,0 +1,41 @@
+#!/usr/bin/env Rscript
+
+## hard-coded list of required packages
+neededPackages <-
+    c("AnnotationDbi", "cowplot", "data.table", "dplyr", "extraDistr",
+      "foreach", "GenomicAlignments", "GenomicFeatures",
+      "GenomicRanges", "ggplot2", "inflection", "Matrix", "mclust",
+      "methods", "parallel", "plyranges", "Rsamtools", "Rsubread",
+      "shiny", "shinyBS", "yaml");
+
+cat("Checking R packages... ");
+
+## remove packages from 'needed' list that have already been installed
+neededPackages <- setdiff(neededPackages, installed.packages()[,1]);
+
+for(p in neededPackages){
+    cat(sprintf("Error: R package '%s' is required; please install\n", p));
+}
+
+if(length(neededPackages) > 0){
+    cat("\nError: one or more packages must be installed (see above)\n\n");
+    cranPackages <-
+        neededPackages[neededPackages %in% available.packages()[,1]];
+    otherPackages <-
+        neededPackages[!(neededPackages %in% available.packages()[,1])];
+    if(length(cranPackages) > 0){
+        cat("CRAN packages [install.packages(...)]:",
+            cranPackages, sep="\n   ");
+        cat("\n");
+    }
+    if(length(otherPackages) > 0){
+        cat("Bioconductor [BiocManager::install(...)] / other packages:",
+            otherPackages, sep="\n   ");
+        cat("\n");
+    }
+    quit(status=1, save="no");
+} else {
+    cat("Great, all required R packages have been installed!\n");
+}
+
+quit(status=1, save="no");

--- a/checkyaml.R
+++ b/checkyaml.R
@@ -121,6 +121,10 @@ cat(" finished file path check\n")
 
 ## Some other variable's validity check
 cat("Checking additional variables... ")
+if(is.null(inp$barcodes$nReadsperCell)) {
+  errorCode <- 1
+  cat("Minimum number of reads per cell [barcodes/nReadsperCell] is not specified.\n")
+}
 if(!is.numeric(inp$num_threads)) {
   errorCode <- 1
   cat("Number of threads should be a number.\n")

--- a/checkyaml.R
+++ b/checkyaml.R
@@ -1,142 +1,134 @@
 #!/usr/bin/env Rscript
 
 suppressMessages(
-    if(!require(yaml)){
+    if(!require(yaml)) {
         stop("Library 'yaml' is needed by R; please install it");
     })
-y<-commandArgs(trailingOnly = T)
 
-inp<-try(read_yaml(y),silent =  T)
+yamlFileName <- commandArgs(trailingOnly = T)[1]
+projectBase <- commandArgs(trailingOnly = T)[2]
 
-e=0
+inp <- try(read_yaml(yamlFileName), silent = T)
 
-if(grepl("try-error",class(inp))) {
-  e=1
-  print(e)
-  stop("Syntax error loading yaml file")
+errorCode <- 0
+
+if(grepl("try-error", class(inp))) {
+  errorCode <- 1
+  cat("Syntax error loading yaml file\n")
+  quit(save="no", status=errorCode)
 }
 
 
 ## Check if mandatory parameters have arguments
 if(is.null(inp$project)) {
-  e=1
-  print("Please provide a project name. It can not be NULL.")
+  errorCode <- 1
+  cat("Please provide a project name. It can not be NULL.\n")
 }
 if(is.null(inp$reference$STAR_index)) {
-  e=1
-  print("Please provide path to STAR index directory. It can not be NULL.")
+  errorCode <- 1
+  cat("Please provide path to STAR index directory. It can not be NULL.\n")
 }
-if(is.null(inp$reference$GTF_file))  {
-  e=1
-  print("Please provide path to GTF file. It can not be NULL.")
-}
-
-if(is.null(inp$out_dir))  {
-  e=1
-  print("Please provide path to output directory. It can not be NULL.")
+if(is.null(inp$reference$GTF_file)) {
+  errorCode <- 1
+  cat("Please provide path to GTF file. It can not be NULL.\n")
 }
 
-if(is.null(unlist(inp$sequence_files)))  {
-  e=1
-  print("You need to provide at least two input fastq files and their base definitions.")
+if(is.null(inp$out_dir)) {
+  errorCode <- 1
+  cat("Please provide path to output directory. It can not be NULL.\n")
 }
 
-lapply(inp$sequence_files, function(x) {
-  if(is.null(x$name) | is.null(x$base_definition)){
-    e=1
-    print("You can not leave out file name or base definition.")
-  }
-} )
+if(is.null(unlist(inp$sequence_files))) {
+  errorCode <- 1
+  cat("You need to provide at least two input fastq files and their base definitions.\n")
+}
 
-
-print(
-  paste(sapply(inp$sequence_files, function(x)
-    if(is.null(unlist(x$base_definition)))  {
-      e=1
-      print("You need to provide base definition for all input files")
-      }else { print("")}
-    )))
-
-print(
-  paste(
-    lapply(seq_along(inp$sequence_files),
-           function(x) {
-             if(is.null(unlist(inp$sequence_files[[x]]$name)))  {
-               e=1
-               print(paste(print(names(inp$sequence_files[x])),
-                           ": You need to provide a path for this input file"))
-               }else{ print("")}
-             })
-))
-print(
-   paste(
-       lapply(seq_along(inp$sequence_files),
-         function(x) {
-           if(is.null(unlist(inp$sequence_files[[x]]$base_definition))) {
-             e=1
-             print(paste(print(names(inp$sequence_files[x])),
-                         ": You need to provide base definitions for this input file"))}
-         })
-  )
-)
-
-lapply(inp$sequence_files,
-       function(x) {
-         if(!is.null(x$base_definition)) {
-           if(any(!grepl("^BC|^UMI|^cDNA",x$base_definition)))  {
-             e=1
-             print("The base definition can only be BC/cDNA/UMI. Check if you have a typo/special characters in your base definition or you forgot to add /space/ after -. Refer to the example yaml in the zUMIs installation directory.")
-           }
-         }
-       })
+cat("Checking file metadata... ")
+for(x in names(inp$sequence_files)) {
+    fileObj <- inp$sequence_files[[x]]
+    if(is.null(fileObj$name) ||
+       is.null(fileObj$base_definition)) {
+        errorCode <- 1
+        cat(x, ": \n", sep="")
+        cat("  You can not leave out file name or base definition.\n")
+    }
+    if(is.null(fileObj$base_definition)) {
+        errorCode <- 1
+        cat(x, ": \n", sep="")
+        cat("  You need to provide a base definition for this file\n")
+    }
+    if(is.null(unlist(fileObj$name))) {
+        errorCode <- 1
+        cat(x, ": \n", sep="")
+        cat("  You need to provide a path for this input file\n")
+    }
+    if(is.null(unlist(fileObj$base_definition))) {
+        errorCode <- 1
+        cat(x, ": \n", sep="")
+        cat("  You need to provide base definitions for this input file")
+    }
+    if(!is.null(fileObj$base_definition)) {
+        if(any(!grepl("^BC|^UMI|^cDNA",fileObj$base_definition))) {
+            errorCode <- 1
+            cat(x, ": \n", sep="")
+            cat("The base definition can only be BC/cDNA/UMI. Check if you have a typo/special characters in your base definition or you forgot to add /space/ after -. Refer to the example yaml in the zUMIs installation directory.\n")
+        }
+    }
+}
+cat(" finished file metadata check\n")
 
 
 ## Check if all the file paths are correct
-
-  lapply(inp$sequence_files,
-       function(x) {
-         if(!is.null(x$name)) {
-           if(!file.exists(x$name))  {
-             e=1
-             print("Please check fastq file paths.")
-           }
-         }
-       })
-
-  if(!is.null(inp$reference$GTF_file)) {
-    if(!file.exists(inp$reference$GTF_file))  {
-      e=1
-      print("GTF file does not exists")
+cat("Checking file paths... ")
+for(x in names(inp$sequence_files)) {
+    fileObj <- inp$sequence_files[[x]]
+    if(!is.null(fileObj$name)) {
+        if(!file.exists(fileObj$name)) {
+            errorCode <- 1
+            cat(x, ": \n", sep="")
+            cat("  fastq file not found\n")
+        }
     }
-  }
-  if(!is.null(inp$reference$STAR_index)) {
-    if(!file.exists(inp$reference$STAR_index))  {
-      e=1
-      print("STAR index does not exists")
+}
+if(!is.null(inp$reference$GTF_file)) {
+    if(!file.exists(inp$reference$GTF_file)) {
+        errorCode <- 1
+        cat("GTF file does not exist\n")
     }
+}
+if(!is.null(inp$reference$STAR_index)) {
+    if(!file.exists(inp$reference$STAR_index)) {
+        errorCode <- 1
+        cat("STAR index does not exist\n")
+    }
+}
+if(!is.null(inp$barcodes$barcode_file)) {
+    if(!file.exists(inp$barcodes$barcode_file)) {
+        errorCode <- 1
+        cat("Please check barcode list file path.\n")
   }
-
-  if(!is.null(inp$barcodes$barcode_file)){
-  if(!file.exists(inp$barcodes$barcode_file))  {
-    e=1
-    print("Please check barcode list file path.")
-  }
-  }
+}
+cat(" finished file path check\n")
 
 ## Some other variable's validity check
-if(!is.numeric(inp$num_threads))  {
-  e=1
-  print("Number of threads should be a number.")
+cat("Checking additional variables... ")
+if(!is.numeric(inp$num_threads)) {
+  errorCode <- 1
+  cat("Number of threads should be a number.\n")
 }
-if(!inp$num_threads >= 1)  {
-  e=1
-  print("Number of threads should be a number >= 1")
+if(!inp$num_threads >= 1) {
+  errorCode <- 1
+  cat("Number of threads should be a number >= 1")
+}
+if(!grepl("Filtering|Mapping|Counting|Summarising",
+          inp$which_Stage, ignore.case = T)) {
+  errorCode <- 1
+  cat("which_stage argument can only be one of these terms: Filtering, Mapping, Counting, Summarising\n")
+}
+cat(" finished variable check\n")
+
+if(errorCode != 0){
+    write(sprintf("YAML file has an error. Look at '%s.zUMIs_YAMLerror.log' or contact developers.\n", projectBase), stderr());
 }
 
-if(!grepl("Filtering|Mapping|Counting|Summarising",inp$which_Stage,ignore.case = T))  {
-  e=1
-  print("which_stage argument can only be one of these terms: Filtering, Mapping, Counting, Summarising")
-}
-
-
-print(e)
+quit(save="no", status=errorCode)

--- a/checkyaml.R
+++ b/checkyaml.R
@@ -108,6 +108,15 @@ if(!is.null(inp$barcodes$barcode_file)) {
         cat("Please check barcode list file path.\n")
   }
 }
+if(is.null(inp$out_dir)) {
+    errorCode <- 1
+    cat("Output directory needs to be specified [out_dir].\n")
+} else {
+    if(!dir.exists(inp$out_dir)) {
+        errorCode <- 1
+        cat(sprintf("Output directory '%s' does not exist.\n", inp$out_dir))
+  }
+}
 cat(" finished file path check\n")
 
 ## Some other variable's validity check

--- a/zUMIs.sh
+++ b/zUMIs.sh
@@ -173,13 +173,12 @@ fi
 ${Rexc} ${zumisdir}/checkyaml.R ${yaml} > ${project}.zUMIs_YAMLerror.log
 iserror=$(tail ${project}.zUMIs_YAMLerror.log -n1 | awk '{print $2}')
 
-${Rexc} ${zumisdir}/checkRequirements.R
-
 if [[ ${iserror} -eq 1 ]] ; then
-    echo "YAML file has an error. Look at the zUMIs_YAMLerror.log or contact developers."
+    echo "YAML file has an error. Look at '${project}.zUMIs_YAMLerror.log' or contact developers."
     exit 1
 fi
 
+${Rexc} ${zumisdir}/checkRequirements.R
 
 echo -e "\n\n You provided these parameters:
  YAML file:	${yaml_orig}

--- a/zUMIs.sh
+++ b/zUMIs.sh
@@ -9,6 +9,8 @@ if [ "$currentv" != "$vers" ] ; then
     echo -e "------------- \n\n Good news! A newer version of zUMIs is available at https://github.com/sdparekh/zUMIs \n\n-------------";
 fi
 
+set -e # abort if *any* commands exist with a nonzero return value
+
 function check_opts() {
     value=$1
     name=$2
@@ -170,6 +172,8 @@ fi
 
 ${Rexc} ${zumisdir}/checkyaml.R ${yaml} > ${project}.zUMIs_YAMLerror.log
 iserror=$(tail ${project}.zUMIs_YAMLerror.log -n1 | awk '{print $2}')
+
+${Rexc} ${zumisdir}/checkRequirements.R
 
 if [[ ${iserror} -eq 1 ]] ; then
     echo "YAML file has an error. Look at the zUMIs_YAMLerror.log or contact developers."

--- a/zUMIs.sh
+++ b/zUMIs.sh
@@ -172,13 +172,8 @@ fi
 
 ${Rexc} ${zumisdir}/checkRequirements.R
 
-${Rexc} ${zumisdir}/checkyaml.R ${yaml} > ${project}.zUMIs_YAMLerror.log
-iserror=$(tail ${project}.zUMIs_YAMLerror.log -n1 | awk '{print $2}')
+${Rexc} ${zumisdir}/checkyaml.R ${yaml} ${project} > ${project}.zUMIs_YAMLerror.log
 
-if [[ ${iserror} -eq 1 ]] ; then
-    echo "YAML file has an error. Look at '${project}.zUMIs_YAMLerror.log' or contact developers."
-    exit 1
-fi
 echo -e "\n\n You provided these parameters:
  YAML file:	${yaml_orig}
  zUMIs directory:		${zumisdir}

--- a/zUMIs.sh
+++ b/zUMIs.sh
@@ -170,6 +170,8 @@ else
     echo "zUMIs_directory: ${zumisdir}" >> ${yaml}
 fi
 
+${Rexc} ${zumisdir}/checkRequirements.R
+
 ${Rexc} ${zumisdir}/checkyaml.R ${yaml} > ${project}.zUMIs_YAMLerror.log
 iserror=$(tail ${project}.zUMIs_YAMLerror.log -n1 | awk '{print $2}')
 
@@ -177,9 +179,6 @@ if [[ ${iserror} -eq 1 ]] ; then
     echo "YAML file has an error. Look at '${project}.zUMIs_YAMLerror.log' or contact developers."
     exit 1
 fi
-
-${Rexc} ${zumisdir}/checkRequirements.R
-
 echo -e "\n\n You provided these parameters:
  YAML file:	${yaml_orig}
  zUMIs directory:		${zumisdir}


### PR DESCRIPTION
Additional syntax checking of config files, and early discovery of potential errors:
* Add additional code to check for installed R libraries
* Change main script to stop at the first error
* Change R code to use standard error handing via quit(status=<num>)
* Cleanup of R code to simplify logic (e.g. "booleanValue == TRUE" -> "booleanValue")
* Cleanup of R code to change `=` outside arguments to `->`
* Cleanup of R code to combine file checks, convert sapply loop [produces output] to for loop [no output needed]
* Cleanup of R code to normalise syntax (e.g. spaces before opening braces, spaces after argument commas)
* Convert R `print` statements into `cat` statements (omits strange '[1]' symbols and quotes from output)

This was all part of my eventual discovery that I should have put `nReadsperCell: 100` into my YAML file, when I actually had `nReadsperCell: 100`. I have also added an additional variable check into the `checkyaml.R` script so that other people won't easily make the same mistake. The effect of this single upper-case-to-lower-case substitution was that zUMIs would happily continue on with doing its thing up to the point where it checked for barcode matching, at which point it complained that there were no barcodes present in the files.