### PR TITLE
Update zUMIs.sh

### DIFF
--- a/zUMIs.sh
+++ b/zUMIs.sh
@@ -247,7 +247,7 @@ if [[ "${whichStage}" == "Filtering" ]] ; then
       pref=$(basename ${f} .gz)
       l=$(ls ${tmpMerge}${pref}* | sed "s|${tmpMerge}${pref}||" | sed 's/.gz//')
   else
-      cat ${f} | head -n 4000000 > ${tmpMerge}/${project}.1mio.check.fq
+      head -n 4000000 ${f} > ${tmpMerge}/${project}.1mio.check.fq
       smallsize=$(stat --printf="%s" ${tmpMerge}/${project}.1mio.check.fq)
       rm ${tmpMerge}/${project}.1mio.check.fq
       nreads=$(expr ${fullsize} \* 1000000 / ${smallsize})


### PR DESCRIPTION
This is a small optimization suggestion. There is no need to use `cat` to pipe `head` since `head` can read the file and stop when reaching the number of lines.

I tested this with a 24GB file, and this are the results:

```bash
$ time head -n 4000000 file.fastq > tmp.fastq
real	0m0.388s
user	0m0.252s
sys	0m0.136s
$ time cat file.fastq | head -n 4000000 > tmp2.fastq
real	0m0.426s
user	0m0.240s
sys	0m0.361s
$ diff tmp.fastq tmp2.fastq
```

At the same time this avoids using pipe and throwing a `cat: write error: Broken pipe` error.