### PR TITLE
Update fqfilter_v2.pl - Fix problem with multiple whitespaces in read-IDs

### DIFF
--- a/fqfilter_v2.pl
+++ b/fqfilter_v2.pl
@@ -305,11 +305,11 @@ while(<$fh1>){
       chomp($rid);
 
       if($rid =~ m/^\@.*\s/){
-        $rid =~ m/^\@(.*)\s/;
+        $rid =~ m/^\@(\S+)/;
         $ridtmp = $1;
       }
       else{
-        $rid =~ m/^\@(.*)/;
+        $rid =~ m/^\@(\S+)/;
         $ridtmp = $1;
       }
 


### PR DESCRIPTION
Hi there,

hope everything is going well in sweden! :)

We recently encountered a small bug within the fqfilter script.
For read-IDs containing multiple whitespaces, only the last part (after the last whitespace) was removed due to greedy pattern matching. 
Subsequently, read-IDs within the *.unmapped.bam can still contain whitespaces, which causes problems when mapping with STAR. 
Adapting the pattern to just match the first non-whitespace character-set within the read-ID fixes this Problem.


Cheers,

Daniel


P.S.: A short example:
Some demultiplexing tools keep the index-combinations within the read-header. This will trigger the bug.
For this read-ID within the fastq file
@VL00118:284:AACMFY5M5:1:1101:33986:1000 1:N:0:0 ACTGAGCG:CGTGTGAT
we would get this read-ID within the unmapped bam
@VL00118:284:AACMFY5M5:1:1101:33986:1000 1:N:0:0

STAR does not throw any error but will fail to get the correct read sequences from the bam, resulting in all reads consisting of only one 'N' within any bam files produced downstream.

